### PR TITLE
A mockup for interactive dragging of points

### DIFF
--- a/WebApp/UI/package-lock.json
+++ b/WebApp/UI/package-lock.json
@@ -13,17 +13,10 @@
         "@codemirror/view": "^0.19.47",
         "@emotion/react": "^11.8.2",
         "@emotion/styled": "^11.8.1",
+        "@flatten-js/core": "^1.3.4",
         "@mui/material": "^5.5.0",
-        "@testing-library/jest-dom": "^5.16.2",
-        "@testing-library/react": "^12.1.3",
-        "@testing-library/user-event": "^13.5.0",
-        "@types/jest": "^27.4.1",
-        "@types/node": "^16.11.26",
-        "@types/react": "^17.0.39",
-        "@types/react-dom": "^17.0.13",
-        "@types/react-virtualized-auto-sizer": "^1.0.1",
-        "@types/react-window": "^1.8.5",
         "assert": "^2.0.0",
+        "lodash": "^4.17.21",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-icons": "^4.3.1",
@@ -33,6 +26,16 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^5.16.2",
+        "@testing-library/react": "^12.1.3",
+        "@testing-library/user-event": "^13.5.0",
+        "@types/jest": "^27.4.1",
+        "@types/lodash": "^4.14.180",
+        "@types/node": "^16.11.26",
+        "@types/react": "^17.0.39",
+        "@types/react-dom": "^17.0.13",
+        "@types/react-virtualized-auto-sizer": "^1.0.1",
+        "@types/react-window": "^1.8.5",
         "typescript": "~4.5.0"
       }
     },
@@ -2453,6 +2456,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@flatten-js/core": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@flatten-js/core/-/core-1.3.4.tgz",
+      "integrity": "sha512-VP8VYWMJPZDgNze83iS//sHHkQREtgtZ9VLn9SNX99FN49AIP/QhSeqkpW0/VPyFrUbrmkw8VumYkT09BH5bYg==",
+      "dependencies": {
+        "@flatten-js/interval-tree": "^1.0.15"
+      },
+      "engines": {
+        "node": ">=4.2.4"
+      }
+    },
+    "node_modules/@flatten-js/interval-tree": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@flatten-js/interval-tree/-/interval-tree-1.0.18.tgz",
+      "integrity": "sha512-o72sZErW0Y1C82Cg7nk82ojJ/22EtmKyp5I3eNqgcOKFp/VCzetATYYjJIqOBBaR7FQ/MFj/ZpsmP38mL4TkYA=="
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -3778,6 +3797,7 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.3.tgz",
       "integrity": "sha512-9LId28I+lx70wUiZjLvi1DB/WT2zGOxUh46glrSNMaWVx849kKAluezVzZrXJfTKKoQTmEOutLes/bHg4Bj3aA==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3796,6 +3816,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3810,6 +3831,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
       "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -3818,6 +3840,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3833,6 +3856,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3843,12 +3867,14 @@
     "node_modules/@testing-library/dom/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/@testing-library/dom/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3857,6 +3883,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3868,6 +3895,7 @@
       "version": "5.16.2",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.2.tgz",
       "integrity": "sha512-6ewxs1MXWwsBFZXIk4nKKskWANelkdUehchEOokHsN8X7c2eKXGw+77aRV63UU8f/DTSVUPLaGxdrj4lN7D/ug==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2",
         "@types/testing-library__jest-dom": "^5.9.1",
@@ -3889,6 +3917,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3903,6 +3932,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
       "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+      "dev": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -3911,6 +3941,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
       "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3923,6 +3954,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3933,12 +3965,14 @@
     "node_modules/@testing-library/jest-dom/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/@testing-library/jest-dom/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3947,6 +3981,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3958,6 +3993,7 @@
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.3.tgz",
       "integrity": "sha512-oCULRXWRrBtC9m6G/WohPo1GLcLesH7T4fuKzRAKn1CWVu9BzXtqLXDDTA6KhFNNtRwLtfSMr20HFl+Qrdrvmg==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0",
@@ -3975,6 +4011,7 @@
       "version": "13.5.0",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
       "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -4005,7 +4042,8 @@
     "node_modules/@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig=="
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.18",
@@ -4168,6 +4206,7 @@
       "version": "27.4.1",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
       "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+      "dev": true,
       "dependencies": {
         "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
@@ -4182,6 +4221,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.180",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.180.tgz",
+      "integrity": "sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==",
+      "dev": true
     },
     "node_modules/@types/mime": {
       "version": "1.3.2",
@@ -4237,6 +4282,7 @@
       "version": "17.0.13",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.13.tgz",
       "integrity": "sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -4261,6 +4307,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.1.tgz",
       "integrity": "sha512-GH8sAnBEM5GV9LTeiz56r4ZhMOUSrP43tAQNSRVxNexDjcNKLCEtnxusAItg1owFUFE6k0NslV26gqVClVvong==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -4269,6 +4316,7 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.5.tgz",
       "integrity": "sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -4325,6 +4373,7 @@
       "version": "5.14.3",
       "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.3.tgz",
       "integrity": "sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==",
+      "dev": true,
       "dependencies": {
         "@types/jest": "*"
       }
@@ -5095,6 +5144,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true,
       "bin": {
         "atob": "bin/atob.js"
       },
@@ -6169,6 +6219,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
       "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+      "dev": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "source-map": "^0.6.1",
@@ -6410,12 +6461,14 @@
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
     },
     "node_modules/css/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6614,6 +6667,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -6852,7 +6906,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz",
-      "integrity": "sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw=="
+      "integrity": "sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==",
+      "dev": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -11595,6 +11650,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
       "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11746,6 +11802,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -14147,6 +14204,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
       "dependencies": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -14873,6 +14931,7 @@
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
       "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
       "deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+      "dev": true,
       "dependencies": {
         "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0"
@@ -15126,6 +15185,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
       "dependencies": {
         "min-indent": "^1.0.0"
       },
@@ -18642,6 +18702,19 @@
         }
       }
     },
+    "@flatten-js/core": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@flatten-js/core/-/core-1.3.4.tgz",
+      "integrity": "sha512-VP8VYWMJPZDgNze83iS//sHHkQREtgtZ9VLn9SNX99FN49AIP/QhSeqkpW0/VPyFrUbrmkw8VumYkT09BH5bYg==",
+      "requires": {
+        "@flatten-js/interval-tree": "^1.0.15"
+      }
+    },
+    "@flatten-js/interval-tree": {
+      "version": "1.0.18",
+      "resolved": "https://registry.npmjs.org/@flatten-js/interval-tree/-/interval-tree-1.0.18.tgz",
+      "integrity": "sha512-o72sZErW0Y1C82Cg7nk82ojJ/22EtmKyp5I3eNqgcOKFp/VCzetATYYjJIqOBBaR7FQ/MFj/ZpsmP38mL4TkYA=="
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -19498,6 +19571,7 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.3.tgz",
       "integrity": "sha512-9LId28I+lx70wUiZjLvi1DB/WT2zGOxUh46glrSNMaWVx849kKAluezVzZrXJfTKKoQTmEOutLes/bHg4Bj3aA==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -19513,6 +19587,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -19520,12 +19595,14 @@
         "aria-query": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
-          "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg=="
+          "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+          "dev": true
         },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -19535,6 +19612,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -19542,17 +19620,20 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -19563,6 +19644,7 @@
       "version": "5.16.2",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.2.tgz",
       "integrity": "sha512-6ewxs1MXWwsBFZXIk4nKKskWANelkdUehchEOokHsN8X7c2eKXGw+77aRV63UU8f/DTSVUPLaGxdrj4lN7D/ug==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
         "@types/testing-library__jest-dom": "^5.9.1",
@@ -19579,6 +19661,7 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -19586,12 +19669,14 @@
         "aria-query": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
-          "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg=="
+          "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+          "dev": true
         },
         "chalk": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
           "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -19601,6 +19686,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -19608,17 +19694,20 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -19629,6 +19718,7 @@
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.3.tgz",
       "integrity": "sha512-oCULRXWRrBtC9m6G/WohPo1GLcLesH7T4fuKzRAKn1CWVu9BzXtqLXDDTA6KhFNNtRwLtfSMr20HFl+Qrdrvmg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.0.0",
@@ -19639,6 +19729,7 @@
       "version": "13.5.0",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
       "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5"
       }
@@ -19656,7 +19747,8 @@
     "@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig=="
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.18",
@@ -19819,6 +19911,7 @@
       "version": "27.4.1",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
       "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+      "dev": true,
       "requires": {
         "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
@@ -19833,6 +19926,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
+    },
+    "@types/lodash": {
+      "version": "4.14.180",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.180.tgz",
+      "integrity": "sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==",
+      "dev": true
     },
     "@types/mime": {
       "version": "1.3.2",
@@ -19888,6 +19987,7 @@
       "version": "17.0.13",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.13.tgz",
       "integrity": "sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -19912,6 +20012,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.1.tgz",
       "integrity": "sha512-GH8sAnBEM5GV9LTeiz56r4ZhMOUSrP43tAQNSRVxNexDjcNKLCEtnxusAItg1owFUFE6k0NslV26gqVClVvong==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -19920,6 +20021,7 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.5.tgz",
       "integrity": "sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -19976,6 +20078,7 @@
       "version": "5.14.3",
       "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.3.tgz",
       "integrity": "sha512-oKZe+Mf4ioWlMuzVBaXQ9WDnEm1+umLx0InILg+yvZVBBDmzV5KfZyLrCvadtWcx8+916jLmHafcmqqffl+iIw==",
+      "dev": true,
       "requires": {
         "@types/jest": "*"
       }
@@ -20542,7 +20645,8 @@
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
     },
     "autoprefixer": {
       "version": "10.4.2",
@@ -21353,6 +21457,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
       "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.4",
         "source-map": "^0.6.1",
@@ -21362,7 +21467,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -21507,7 +21613,8 @@
     "css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
-      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s="
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
     },
     "cssdb": {
       "version": "6.4.0",
@@ -21656,7 +21763,8 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "dedent": {
       "version": "0.7.0",
@@ -21842,7 +21950,8 @@
     "dom-accessibility-api": {
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz",
-      "integrity": "sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw=="
+      "integrity": "sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -25263,7 +25372,8 @@
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
     },
     "magic-string": {
       "version": "0.25.8",
@@ -25374,7 +25484,8 @@
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
     },
     "mini-css-extract-plugin": {
       "version": "2.5.3",
@@ -26988,6 +27099,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -27517,6 +27629,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
       "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+      "dev": true,
       "requires": {
         "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0"
@@ -27719,6 +27832,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
       "requires": {
         "min-indent": "^1.0.0"
       }

--- a/WebApp/UI/package.json
+++ b/WebApp/UI/package.json
@@ -8,8 +8,10 @@
     "@codemirror/view": "^0.19.47",
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
+    "@flatten-js/core": "^1.3.4",
     "@mui/material": "^5.5.0",
     "assert": "^2.0.0",
+    "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",
@@ -23,6 +25,7 @@
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.4.1",
+    "@types/lodash": "^4.14.180",
     "@types/node": "^16.11.26",
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.13",
@@ -31,7 +34,7 @@
     "typescript": "~4.5.0"
   },
   "scripts": {
-    "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/WebApp/UI/src/components/DrawingArea/DrawingArea.css
+++ b/WebApp/UI/src/components/DrawingArea/DrawingArea.css
@@ -14,10 +14,12 @@ g.grid path.axis {
 }
 
 g.grid path.tick {
+    vector-effect: non-scaling-stroke;
     stroke: #ddf;
 }
 
 g.diagram g.labeledPoint circle {
+    vector-effect: non-scaling-stroke;
     r: 4px;
     fill: rgb(255, 0, 140);
     stroke: rgb(168 47 176);

--- a/WebApp/UI/src/components/DrawingArea/DrawingArea.css
+++ b/WebApp/UI/src/components/DrawingArea/DrawingArea.css
@@ -23,6 +23,10 @@ g.diagram g.labeledPoint circle {
     stroke: rgb(168 47 176);
 }
 
+g.diagram g.labeledPoint.mobile circle:hover {
+    stroke-width: 3px;
+}
+
 g.diagram g.labeledPoint text {
     text-anchor: end;
     dominant-baseline: middle;

--- a/WebApp/UI/src/components/DrawingArea/DrawingArea.tsx
+++ b/WebApp/UI/src/components/DrawingArea/DrawingArea.tsx
@@ -67,16 +67,73 @@ class DrawingArea extends React.Component<DrawingAreaProps> {
     renderPoints(points: LabeledPoint[] = []) {
         var ofs = this.labelOffset;
         return points.map(({label, at: {x, y}}) =>
-            <g key={label} className="labeledPoint">
+            <g key={label} className="labeledPoint mobile"
+                        onPointerDownCapture={ev => this.pointDrag.start(ev, label)}
+                        onPointerMove={ev => this.pointDrag.move(ev, label)}
+                        onPointerUp={ev => this.pointDrag.end(ev, label)}>
                 {['stroked', 'fore'].map(cs =>
-                    <text key={cs} className={cs} x={x + ofs.x} y={y + ofs.y}>{label}</text>)}
-                <circle cx={x} cy={y}/>
+                    <text key={cs} className={cs} x={x + ofs.x} y={-y + ofs.y}>{label}</text>)}
+                <circle cx={x} cy={-y}/>
             </g>);
     }
 
+    pointDrag = new DrawingAreaGesture(this)
+
     _mkticks(from: number, to: number, sep: number) {
         return new Array(Math.floor((to - from) / sep)).fill(0)
-            .map((_,i) => from + (i + 1) * sep).filter(x => x != 0);
+            .map((_,i) => from + (i + 1) * sep).filter(x => x !== 0);
+    }
+}
+
+
+class DrawingAreaGesture {
+    active?: PointDragGesture
+
+    constructor(private drawingArea: DrawingArea) { }
+
+    start(ev: React.PointerEvent, label: string) {
+        this.active = PointDragGesture.start(ev, label, this.drawingArea);
+    }
+    move(ev: React.PointerEvent, label: string) {
+        this.active?.move(ev, label);
+    }
+    end(ev: React.PointerEvent, label: string) {
+        this.active?.end(ev, label);
+        this.active = undefined;
+    }
+}
+
+
+class PointDragGesture {
+    start: PointXY
+    initial: LabeledPoint
+    hook: (pt: LabeledPoint) => void
+
+    constructor(start: PointXY, initial: LabeledPoint, hook: (pt: LabeledPoint) => void) {
+        this.start = start;
+        this.initial = initial;
+        this.hook = hook;
+    }
+
+    static start(ev: React.PointerEvent, label: string, drawingArea: DrawingArea) {
+        let pt = drawingArea.props.points?.find(pt => pt.label === label);
+        if (pt) {
+            (ev.target as Element).setPointerCapture(ev.pointerId);
+            ev.stopPropagation();
+            return new PointDragGesture(
+                {x: ev.clientX, y: ev.clientY}, 
+                pt, drawingArea.props.onMovePoint!);
+        }
+    }
+
+    move(ev: React.PointerEvent, label: string) {
+        let delta = {x: ev.clientX - this.start.x, y: ev.clientY - this.start.y},
+            o = this.initial;
+        this.hook({label: o.label, at: {x: o.at.x + delta.x, y: o.at.y - delta.y}});
+    }
+
+    end(ev: React.PointerEvent, label: string) {
+        (ev.target as Element).releasePointerCapture(ev.pointerId);
     }
 }
 
@@ -84,7 +141,10 @@ class DrawingArea extends React.Component<DrawingAreaProps> {
 type DrawingAreaProps = {
     ticksep?: number
     points?: LabeledPoint[]
+    onMovePoint?: (pt: LabeledPoint) => void
 };
+
+type PointXY = {x: number, y: number}
 
 
 export { DrawingArea }

--- a/WebApp/UI/src/components/MainContent/MainContent.tsx
+++ b/WebApp/UI/src/components/MainContent/MainContent.tsx
@@ -1,12 +1,15 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import './MainContent.css';
 import { DrawingArea } from '../DrawingArea/DrawingArea';
 import { SideBar } from '../SideBar/SideBar';
 import { Shapes, LabeledPoint } from '../DrawingArea/Shapes';
-import { MiniInterp, PointSet } from '../../mini-solve';
+import { MiniInterp, PointSet } from '../../solve/mini-solve';
+import MOCK_PROGRAMS from '../../solve/mock-programs';
 
 
 class MainContent extends React.Component<{}, MainContentState> {
+
+    interp?: MiniInterp
 
     constructor(props: {}) {
         super(props);
@@ -16,13 +19,22 @@ class MainContent extends React.Component<{}, MainContentState> {
     }
 
     solveAndSetPoints(points: LabeledPoint[]) {
-        var interp = new MiniInterp(), pointset = PointSet.fromLabeledPoints(points),
-            sol = interp.eval(pointset);
-        this.setState({points: PointSet.toLabeledPoints({...pointset, ...sol})});
+        if (this.interp) {
+            var pointset = PointSet.fromLabeledPoints(points),
+                sol = this.interp.eval(pointset);
+            points = PointSet.toLabeledPoints(sol);
+        }
+        this.setState({points});
     }
 
     handleShapesReceived = (shapes: Shapes) => {
         if (shapes.points) this.solveAndSetPoints(shapes.points);
+    }
+
+    onOpened = (name: string, defs: any) => {
+        var mock = MOCK_PROGRAMS[name];
+        this.interp = mock ? new MiniInterp(mock) : undefined;
+        console.log(this.interp);
     }
 
     onMovePoint = (pt: LabeledPoint) => {
@@ -32,7 +44,7 @@ class MainContent extends React.Component<{}, MainContentState> {
     render() {
         return (            
             <div className="main-content-container">
-                <SideBar onShapesReceived={this.handleShapesReceived}/>
+                <SideBar onOpened={this.onOpened} onShapesReceived={this.handleShapesReceived}/>
                 <DrawingArea points={this.state.points} onMovePoint={this.onMovePoint}/>
             </div>
         )

--- a/WebApp/UI/src/components/MainContent/MainContent.tsx
+++ b/WebApp/UI/src/components/MainContent/MainContent.tsx
@@ -3,22 +3,44 @@ import './MainContent.css';
 import { DrawingArea } from '../DrawingArea/DrawingArea';
 import { SideBar } from '../SideBar/SideBar';
 import { Shapes, LabeledPoint } from '../DrawingArea/Shapes';
+import { MiniInterp, PointSet } from '../../mini-solve';
 
 
-export const MainContent = () => {
-    
-    var [points, setPoints] = React.useState<LabeledPoint[]>([]);
+class MainContent extends React.Component<{}, MainContentState> {
 
-    const handleShapesReceived = (shapes: Shapes) => {
-        if (shapes.points) setPoints(shapes.points);
+    constructor(props: {}) {
+        super(props);
+        this.state = {
+            points: []
+        };
     }
 
-    return (
-        
-        <div className="main-content-container">
-            <SideBar onShapesReceived={handleShapesReceived}/>
-            <DrawingArea points={points}/>
-        </div>
-        
-    )
+    solveAndSetPoints(points: LabeledPoint[]) {
+        var interp = new MiniInterp(), pointset = PointSet.fromLabeledPoints(points),
+            sol = interp.eval(pointset);
+        this.setState({points: PointSet.toLabeledPoints({...pointset, ...sol})});
+    }
+
+    handleShapesReceived = (shapes: Shapes) => {
+        if (shapes.points) this.solveAndSetPoints(shapes.points);
+    }
+
+    onMovePoint = (pt: LabeledPoint) => {
+        this.solveAndSetPoints(this.state.points.map(lpt => pt.label === lpt.label ? pt : lpt));
+    }
+
+    render() {
+        return (            
+            <div className="main-content-container">
+                <SideBar onShapesReceived={this.handleShapesReceived}/>
+                <DrawingArea points={this.state.points} onMovePoint={this.onMovePoint}/>
+            </div>
+        )
+    }
 }
+
+
+type MainContentState = {points: LabeledPoint[]}
+
+
+export { MainContent }

--- a/WebApp/UI/src/components/SideBar/SideBar.tsx
+++ b/WebApp/UI/src/components/SideBar/SideBar.tsx
@@ -89,6 +89,7 @@ class SideBar extends React.Component<SideBarProps, SideBarState> {
                         at: {x: +value.x, y: +value.y}
                     };
             }
+            return undefined;
         }).filter(x => x) as LabeledPoint[];
         console.log(pts);
         this.props.onShapesReceived?.({points: pts});

--- a/WebApp/UI/src/components/SideBar/SideBar.tsx
+++ b/WebApp/UI/src/components/SideBar/SideBar.tsx
@@ -29,7 +29,7 @@ class SideBar extends React.Component<SideBarProps, SideBarState> {
     editor = React.createRef<Editor>()
     listOfSamples = React.createRef<ListOfSamples>()
 
-    readonly DEFAULT_SAMPLE = "triangle"
+    readonly DEFAULT_SAMPLE = "square"
 
     constructor(props: {}) {
         super(props);
@@ -51,6 +51,7 @@ class SideBar extends React.Component<SideBarProps, SideBarState> {
         console.log('compile', this.state.userRules);
         var compiled = await this.compileText(this.state.userRules);
         this.setState({parsedInput: compiled.statements});
+        this.props.onCompiled?.(compiled.statements);
         this.extractPoints(compiled.statements);
     }
 
@@ -68,11 +69,13 @@ class SideBar extends React.Component<SideBarProps, SideBarState> {
 
     openSample(name: string) {
         var sample = this.state.samples[name];
-        if (sample)
+        if (sample) {
             this.editor.current?.open(sample.join('\n'));
+            this.props.onOpened?.(name, sample);
+        }
     }
 
-    async compileText(programText: string) {
+    async compileText(programText: string): Promise<{statements: Statement[]}> {
         var r = await fetch('/compile', {method: 'POST', body: programText});
         if (!r.ok) throw r;
         return await r.json();
@@ -150,6 +153,8 @@ class SideBar extends React.Component<SideBarProps, SideBarState> {
 }
 
 type SideBarProps = {
+    onOpened?: (name: string, defs: any) => void
+    onCompiled?: (statements: Statement[]) => void
     onShapesReceived?: (shapes: Shapes) => void
 }
 

--- a/WebApp/UI/src/mini-solve.ts
+++ b/WebApp/UI/src/mini-solve.ts
@@ -1,0 +1,144 @@
+import assert from 'assert';
+import _ from 'lodash';
+import Flatten from '@flatten-js/core';
+import type { LabeledPoint } from './components/DrawingArea/Shapes';
+
+
+class MiniInterp {
+    eval(inputPoints: PointSet) {
+        var known = this._import(inputPoints);
+
+        if (['X', 'Z'].every(k => inputPoints[k])) {
+            let x = known['X'], z = known['Z'], d = x.distanceTo(z)[0],
+                c1 = Flatten.circle(x, d),
+                c2 = Flatten.circle(z, d);
+
+            var sol = c1.intersect(c2);
+
+            return this._export({
+                'Y': sol[0]
+            });
+        }
+        else if (['A', 'B'].every(k => inputPoints[k])) {
+            var a = known['A'], b = known['B'], dist = a.distanceTo(b)[0];
+                
+
+            let prog: Instruction[] = [
+                [1, 'C', (env: Env) => 
+                            this._searchOnCircleAroundPoint_maybe(
+                                Flatten.circle(env['B'], dist), env['C'])],
+                [0, 'D', (env: Env) =>
+                            Flatten.circle(env['C'], dist)
+                                .intersect(Flatten.circle(env['A'], dist))]
+            ];
+            let objective = (pts: Env) =>
+                (pts.D.distanceTo(pts.A)[0] < 1 ? 10 : 0) + // penalty
+                (pts.D.distanceTo(pts.B)[0] < 1 ? 10 : 0) + // penalty
+                Math.abs(pts.A.distanceTo(pts.C)[0] - pts.B.distanceTo(pts.D)[0]);
+        
+            var candidates = this._compile(prog)(known)
+                    .map(env => ({values: env, err: objective(env)}));
+            var minimal = _.minBy(candidates, oc => oc.err);
+
+            assert(minimal);
+
+            return this._export(minimal.values);
+        }
+        else return {};
+    }
+
+    _import(ps: PointSet): PointSet<Flatten.Point> {
+        return mapValues(ps, v => Flatten.point(v.x, v.y));
+    }
+
+    _export(ps: PointSet<Flatten.Point>): PointSet {
+        return mapValues(ps, v => ({x: v.x, y: v.y}));
+    }
+
+    _searchOnCircle(c: Flatten.Circle): SearchRange<Flatten.Point> {
+        let p0 = new Flatten.Point(c.pc.x + c.r, c.pc.y);
+        return {lo: 0, hi: 2 * Math.PI,
+            construct: (angle: number) => p0.rotate(angle, c.pc)}
+    }
+
+    _searchOnCircleAroundPoint(c: Flatten.Circle, pt: Flatten.Point): SearchRange<Flatten.Point> {
+        let p0 = new Flatten.Point(c.pc.x + c.r, c.pc.y),
+            around = new Flatten.Vector(c.pc, pt).slope;
+        return {lo: around - 0.5, hi: around + 0.5,
+            construct: (angle: number) => p0.rotate(angle, c.pc)}
+    }
+
+    _searchOnCircleAroundPoint_maybe(c: Flatten.Circle, pt?: Flatten.Point): SearchRange<Flatten.Point> {
+        return pt ? this._searchOnCircleAroundPoint(c, pt) : this._searchOnCircle(c);
+    }
+
+    _slice(sr: SearchRange<Flatten.Point>, nSlices: number = 1000) {
+        return _.range(sr.lo, sr.hi, (sr.hi - sr.lo) / nSlices)
+            .map(p => sr.construct(p));
+    }
+
+    _in0(env: Env, key: string, sr: Locus0, cont: (env: Env) => Env[]) {
+        return _.flatten(sr.map(pt => cont({...env, [key]: pt})));        
+    }
+
+    _in1(env: Env, key: string, sr: Locus1, cont: (env: Env) => Env[]) {
+        return this._in0(env, key, this._slice(sr), cont);
+    }
+
+    _bind0(key: string, stmt: (env: Env) => Locus0, cont: (env: Env) => Env[]) {
+        return (env: Env) => this._in0(env, key, stmt(env), cont);
+    }
+
+    _bind1(key: string, stmt: (env: Env) => Locus1, cont: (env: Env) => Env[]) {
+        return (env: Env) => this._in1(env, key, stmt(env), cont);
+    }
+
+    _ret() { return (env: Env) => [env]; }
+
+    _compile(instructions: Instruction[]): (env: Env) => Env[] {
+        if (instructions.length === 0) return this._ret();
+        else {
+            var insn = instructions[0], rest = instructions.slice(1);
+            switch (insn[0]) {
+            case 0:
+                return this._bind0(insn[1], insn[2], this._compile(rest));
+            case 1:
+                return this._bind1(insn[1], insn[2], this._compile(rest));
+            default:
+                assert(false);
+            }
+        }
+    }
+}
+
+
+function mapValues<T, S>(o: {[key: string]: T}, f: (t: T) => S) {
+    return Object.fromEntries(Object.entries(o).map(([k, v]) => [k, f(v)]));
+}
+
+
+export type PointXY = {x: number, y: number};
+
+type PointSet<P extends PointXY = PointXY> = {[name: string]: P};
+
+namespace PointSet {
+    export function fromLabeledPoints(points: LabeledPoint[]) {
+        return Object.fromEntries(points.map(o => [o.label, o.at]));
+    }
+
+    export function toLabeledPoints(points: PointSet) {
+        return Object.entries(points).map(([k, v]) => ({label: k, at: v}));
+    }
+}
+
+type SearchRange<T> = {lo: number, hi: number, construct: (p: number) => T}
+
+type Env = PointSet<Flatten.Point>
+type Locus0 = Flatten.Point[]
+type Locus1 = SearchRange<Flatten.Point>
+type Expr<Locus> = (env: Env) => Locus
+
+type Instruction = [0, string, Expr<Locus0>] | [1, string, Expr<Locus1>]
+
+
+export { MiniInterp, PointSet }

--- a/WebApp/UI/src/solve/mini-solve.ts
+++ b/WebApp/UI/src/solve/mini-solve.ts
@@ -1,11 +1,37 @@
 import assert from 'assert';
 import _ from 'lodash';
 import Flatten from '@flatten-js/core';
-import type { LabeledPoint } from './components/DrawingArea/Shapes';
+import type { LabeledPoint } from '../components/DrawingArea/Shapes';
 
 
 class MiniInterp {
+    prog: Expr<MiniProgram>
+
+    constructor(prog: Expr<MiniProgram>) {
+        this.prog = prog;
+    }
+
     eval(inputPoints: PointSet) {
+        var known = this._import(inputPoints);
+        try {
+            var prog = this.prog(known);
+        }
+        catch (e) {
+            if (e instanceof MiniProgram.MissingInputs)
+                return known;
+            else throw e;
+        }
+
+        var candidates = this._compile(prog.stmts)(known)
+                .map(env => ({values: env, err: prog.objfunc(env)}));
+        var minimal = _.minBy(candidates, oc => oc.err);
+
+        assert(minimal);
+
+        return this._export(minimal.values);
+    }
+
+    peval(inputPoints: PointSet) {
         var known = this._import(inputPoints);
 
         if (['X', 'Z'].every(k => inputPoints[k])) {
@@ -23,21 +49,22 @@ class MiniInterp {
             var a = known['A'], b = known['B'], dist = a.distanceTo(b)[0];
                 
 
-            let prog: Instruction[] = [
-                [1, 'C', (env: Env) => 
-                            this._searchOnCircleAroundPoint_maybe(
-                                Flatten.circle(env['B'], dist), env['C'])],
-                [0, 'D', (env: Env) =>
-                            Flatten.circle(env['C'], dist)
-                                .intersect(Flatten.circle(env['A'], dist))]
-            ];
-            let objective = (pts: Env) =>
-                (pts.D.distanceTo(pts.A)[0] < 1 ? 10 : 0) + // penalty
-                (pts.D.distanceTo(pts.B)[0] < 1 ? 10 : 0) + // penalty
-                Math.abs(pts.A.distanceTo(pts.C)[0] - pts.B.distanceTo(pts.D)[0]);
+            let prog = new MiniProgram([
+                    [1, 'C', (env: Env) => 
+                                SearchRange.circleAroundPoint_maybe(
+                                    Flatten.circle(env['B'], dist), env['C'])],
+                    [0, 'D', (env: Env) =>
+                                Flatten.circle(env['C'], dist)
+                                    .intersect(Flatten.circle(env['A'], dist))]
+                ],
+                (pts: Env) =>
+                    (pts.D.distanceTo(pts.A)[0] < 1 ? 10 : 0) + // penalty
+                    (pts.D.distanceTo(pts.B)[0] < 1 ? 10 : 0) + // penalty
+                    Math.abs(pts.A.distanceTo(pts.C)[0] - pts.B.distanceTo(pts.D)[0])
+            );
         
-            var candidates = this._compile(prog)(known)
-                    .map(env => ({values: env, err: objective(env)}));
+            var candidates = this._compile(prog.stmts)(known)
+                    .map(env => ({values: env, err: prog.objfunc(env)}));
             var minimal = _.minBy(candidates, oc => oc.err);
 
             assert(minimal);
@@ -53,23 +80,6 @@ class MiniInterp {
 
     _export(ps: PointSet<Flatten.Point>): PointSet {
         return mapValues(ps, v => ({x: v.x, y: v.y}));
-    }
-
-    _searchOnCircle(c: Flatten.Circle): SearchRange<Flatten.Point> {
-        let p0 = new Flatten.Point(c.pc.x + c.r, c.pc.y);
-        return {lo: 0, hi: 2 * Math.PI,
-            construct: (angle: number) => p0.rotate(angle, c.pc)}
-    }
-
-    _searchOnCircleAroundPoint(c: Flatten.Circle, pt: Flatten.Point): SearchRange<Flatten.Point> {
-        let p0 = new Flatten.Point(c.pc.x + c.r, c.pc.y),
-            around = new Flatten.Vector(c.pc, pt).slope;
-        return {lo: around - 0.5, hi: around + 0.5,
-            construct: (angle: number) => p0.rotate(angle, c.pc)}
-    }
-
-    _searchOnCircleAroundPoint_maybe(c: Flatten.Circle, pt?: Flatten.Point): SearchRange<Flatten.Point> {
-        return pt ? this._searchOnCircleAroundPoint(c, pt) : this._searchOnCircle(c);
     }
 
     _slice(sr: SearchRange<Flatten.Point>, nSlices: number = 1000) {
@@ -133,12 +143,49 @@ namespace PointSet {
 
 type SearchRange<T> = {lo: number, hi: number, construct: (p: number) => T}
 
+namespace SearchRange {
+
+    export function circle(c: Flatten.Circle): SearchRange<Flatten.Point> {
+        let p0 = new Flatten.Point(c.pc.x + c.r, c.pc.y);
+        return {lo: 0, hi: 2 * Math.PI,
+            construct: (angle: number) => p0.rotate(angle, c.pc)}
+    }
+
+    export function circleAroundPoint(c: Flatten.Circle, pt: Flatten.Point): SearchRange<Flatten.Point> {
+        let p0 = new Flatten.Point(c.pc.x + c.r, c.pc.y),
+            around = new Flatten.Vector(c.pc, pt).slope;
+        return {lo: around - 0.5, hi: around + 0.5,
+            construct: (angle: number) => p0.rotate(angle, c.pc)}
+    }
+
+    export function circleAroundPoint_maybe(c: Flatten.Circle, pt?: Flatten.Point): SearchRange<Flatten.Point> {
+        return pt ? circleAroundPoint(c, pt) : circle(c);
+    }
+
+}
+
 type Env = PointSet<Flatten.Point>
 type Locus0 = Flatten.Point[]
 type Locus1 = SearchRange<Flatten.Point>
-type Expr<Locus> = (env: Env) => Locus
+type Expr<Ty> = (env: Env) => Ty
 
 type Instruction = [0, string, Expr<Locus0>] | [1, string, Expr<Locus1>]
+type ObjectiveFunction = Expr<number>
+
+class MiniProgram {
+    constructor(public stmts: Instruction[],
+        public objfunc: ObjectiveFunction) { }
+}
+
+type _Env = Env;
+type _Expr<Ty> = Expr<Ty>;
+
+namespace MiniProgram {
+    export type Env = _Env;
+    export type Expr<Ty> = _Expr<Ty>;
+
+    export class MissingInputs { }
+}
 
 
-export { MiniInterp, PointSet }
+export { MiniInterp, PointSet, SearchRange, MiniProgram }

--- a/WebApp/UI/src/solve/mock-programs.ts
+++ b/WebApp/UI/src/solve/mock-programs.ts
@@ -1,0 +1,45 @@
+import Flatten from '@flatten-js/core';
+import { MiniProgram, SearchRange } from './mini-solve';
+
+
+const MOCK_TRIANGLE = (known: MiniProgram.Env) => {
+    if (['X', 'Z'].every(k => known[k])) {
+        let x = known['X'], z = known['Z'], d = x.distanceTo(z)[0],
+            c1 = Flatten.circle(x, d),
+            c2 = Flatten.circle(z, d);
+
+        return new MiniProgram([
+                [0, 'Y', _ => c1.intersect(c2)]
+            ],
+            _ => 0
+        );
+    }
+    else throw new MiniProgram.MissingInputs();
+}
+
+const MOCK_SQUARE = (known: MiniProgram.Env) => {
+    if (['A', 'B'].every(k => known[k])) {
+        var a = known['A'], b = known['B'], dist = a.distanceTo(b)[0];
+            
+        return new MiniProgram([
+                [1, 'C', env => 
+                            SearchRange.circleAroundPoint_maybe(
+                                Flatten.circle(env['B'], dist), env['C'])],
+                [0, 'D', env =>
+                            Flatten.circle(env['C'], dist)
+                                .intersect(Flatten.circle(env['A'], dist))]
+            ],
+            env =>
+                (env['D'].distanceTo(env['A'])[0] < 1 ? 10 : 0) + // penalty
+                (env['D'].distanceTo(env['B'])[0] < 1 ? 10 : 0) + // penalty
+                Math.abs(env['A'].distanceTo(env['C'])[0] - env['B'].distanceTo(env['D'])[0])
+        );   
+    }
+    else throw new MiniProgram.MissingInputs();
+}
+
+
+export default {
+    triangle: MOCK_TRIANGLE,
+    square: MOCK_SQUARE
+} as {[name: string]: MiniProgram.Expr<MiniProgram>}

--- a/WebApp/UI/src/solve/mock-programs.ts
+++ b/WebApp/UI/src/solve/mock-programs.ts
@@ -38,8 +38,32 @@ const MOCK_SQUARE = (known: MiniProgram.Env) => {
     else throw new MiniProgram.MissingInputs();
 }
 
+const MOCK_SQUARE_IN_SQUARE = (known: MiniProgram.Env) => {
+    if (['A', 'B'].every(k => known[k])) {
+        var a = known['A'], b = known['B'], dist = a.distanceTo(b)[0];
+            
+        return new MiniProgram([
+                MOCK_SQUARE,
+                ienv => new MiniProgram([
+                    [1, 'E', env => SearchRange.segmentAroundPoint_maybe(Flatten.segment(env['A'], env['B']), env['E']) ]
+                ], env => env['E'].distanceTo(ienv['E'] ?? Flatten.segment(env['A'], env['B']).middle())[0]),
+                [1, 'F', env => SearchRange.segmentAroundPoint_maybe(Flatten.segment(env['B'], env['C']), env['F']) ],
+                [0, 'G', env =>
+                    Flatten.circle(env['F'], env['F'].distanceTo(env['E'])[0]).intersect(
+                        Flatten.segment(env['C'], env['D']))],
+                [0, 'H', env =>
+                    Flatten.circle(env['G'], env['F'].distanceTo(env['E'])[0]).intersect(
+                        Flatten.segment(env['A'], env['D']))],
+            ], env => Math.abs(env['E'].distanceTo(env['F'])[0] - 
+                               env['E'].distanceTo(env['H'])[0])
+        );   
+    }
+    else throw new MiniProgram.MissingInputs();
+}
+
 
 export default {
     triangle: MOCK_TRIANGLE,
-    square: MOCK_SQUARE
+    square: MOCK_SQUARE,
+    'square-in-square': MOCK_SQUARE_IN_SQUARE
 } as {[name: string]: MiniProgram.Expr<MiniProgram>}


### PR DESCRIPTION
Of course, we are not going to be able to implement interactivity in time for the fair, but I thought we can showcase its potential with a simple mockup. (It isn't cheating as long as we say that it's a mockup 🤡)

So I have introduced a mini-solver on the client side that mimics what the server-side solver does with sympy, using a naïve hillclimbing approach and assuming that points are not going to move too much relative to their previously solved locations. This is a reasonable assumption for dragging gestures. I have implemented mockup programs for `triangle` and `square`, and it should be not so hard to hand-craft a few more. (See `UI/src/solve/mock-programs.ts`)

Looking forward to getting the first "real" results from the sympy solver, as well as the lines and segments 😃 

<img width="1086" alt="Screen Shot 2022-03-22 at 23 37 05" src="https://user-images.githubusercontent.com/704372/159580537-485ffc85-6366-41ff-a4df-2c72e8167cb1.png">
 